### PR TITLE
fix: improve upgrade automation script

### DIFF
--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -333,6 +333,10 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
             if req['new_version'] and req['old_version']:  # if both values exits then do version comparison
                 old_version = Version(req['old_version'])
                 new_version = Version(req['new_version'])
+
+                # skip, if the package location is changed in txt file only and both versions are same
+                if old_version == new_version:
+                    continue
                 if new_version > old_version:
                     if new_version.major == old_version.major:
                         valid_reqs.append(req)

--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -286,7 +286,6 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
             if not suspicious_reqs and valid_reqs:
                 pull_request.set_labels('Ready to Merge')
                 logger.info("Total valid upgrades are %s", valid_reqs)
-                self._add_comment_about_reqs(pull_request, "Valid upgraded packages", valid_reqs)
             else:
                 self._add_comment_about_reqs(pull_request, "These Packages need manual review.", suspicious_reqs)
 

--- a/jenkins/tests/test_data/diff.txt
+++ b/jenkins/tests/test_data/diff.txt
@@ -350,12 +350,14 @@ index 284c0b0..191d25a 100644
 +    # via tox
 +certifi==2022.12.7
      # via requests
++codecov==2.1.12
++    # via -r requirements/travis.in
 +chardet==5.1.0
 +    # via tox
  charset-normalizer==2.1.1
      # via requests
- codecov==2.1.12
-     # via -r requirements/travis.in
+-codecov==2.1.12
+-    # via -r requirements/travis.in
 +colorama==0.4.6
 +    # via tox
  coverage==6.5.0


### PR DESCRIPTION
Skip, if the package location is changed in the txt file only and both versions are the same.